### PR TITLE
Prepare for external docker image build

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -2,7 +2,7 @@ steps:
   - plugins:
       # You'll need to use the git+ssh, the linter requires the nice name
       # - ssh://git@github.com/equinixmetal/github-releases-download-buildkite-plugin#v1.0.0:
-      - equinixmetal/github-releases-download#v1.0.0:
+      - equinixmetal/github-releases-download#v0.0.1:
           github_org: metal-toolbox
           repo: vogelkop
           binary_name: vogelkop

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,11 +1,14 @@
 steps:
-  - plugins:
-      # You'll need to use the git+ssh, the linter requires the nice name
-      # - ssh://git@github.com/equinixmetal/github-releases-download-buildkite-plugin#v1.0.0:
-      - equinixmetal/github-releases-download#v0.0.1:
-          github_org: metal-toolbox
-          repo: vogelkop
-          binary_name: vogelkop
-          filter: linux-amd64
-  - trigger: "vogelkop"
-    if: build.branch == "main" || build.tag =~ /^v[0-9]+\.[0-9]+\.[0-9]+[-staging]*\$/
+  - label: ":golang: get vogelkop-amd64 binary"
+    key: vogelkop
+    plugins:
+    - ssh://git@github.com/equinixmetal/github-releases-download-buildkite-plugin#v0.0.1:
+        github_org: metal-toolbox
+        repo: vogelkop
+        binary_name: vogelkop
+        filter: linux_amd64
+    - ssh://git@github.com/equinixmetal/ssm-buildkite-plugin#v1.0.3:
+        parameters:
+          GITHUB_PAT: /buildkite/github/personal-access-token/v1
+  # - trigger: "vogelkop"
+  #   if: build.branch == "main" || build.tag =~ /^v[0-9]+\.[0-9]+\.[0-9]+[-staging]*\$/

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,14 +1,22 @@
+# steps:
+#   - label: ":golang: get vogelkop-amd64 binary"
+#     key: vogelkop
+#     plugins:
+#     - ssh://git@github.com/equinixmetal/github-releases-download-buildkite-plugin#v0.0.1:
+#         github_org: metal-toolbox
+#         repo: vogelkop
+#         binary_name: vogelkop
+#         filter: linux_amd64
+#     - ssh://git@github.com/equinixmetal/ssm-buildkite-plugin#v1.0.3:
+#         parameters:
+#           GITHUB_PAT: /buildkite/github/personal-access-token/v1
+#   # - trigger: "vogelkop"
+#   #   if: build.branch == "main" || build.tag =~ /^v[0-9]+\.[0-9]+\.[0-9]+[-staging]*\$/
+
 steps:
-  - label: ":golang: get vogelkop-amd64 binary"
-    key: vogelkop
-    plugins:
-    - ssh://git@github.com/equinixmetal/github-releases-download-buildkite-plugin#v0.0.1:
-        github_org: metal-toolbox
-        repo: vogelkop
-        binary_name: vogelkop
-        filter: linux_amd64
-    - ssh://git@github.com/equinixmetal/ssm-buildkite-plugin#v1.0.3:
-        parameters:
-          GITHUB_PAT: /buildkite/github/personal-access-token/v1
-  # - trigger: "vogelkop"
-  #   if: build.branch == "main" || build.tag =~ /^v[0-9]+\.[0-9]+\.[0-9]+[-staging]*\$/
+  - trigger: "vogelkop-inband"
+    if: build.branch == "main" || build.tag =~ /^v[0-9]+\.[0-9]+\.[0-9]+[-staging]*\$/
+    build:
+      env:
+        VOGELKOP_TAG: "${BUILDKITE_TAG}"
+        VOGELKOP_COMMIT: "${BUILDKITE_COMMIT}"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,0 +1,11 @@
+steps:
+  - plugins:
+      # You'll need to use the git+ssh, the linter requires the nice name
+      # - ssh://git@github.com/equinixmetal/github-releases-download-buildkite-plugin#v1.0.0:
+      - equinixmetal/github-releases-download#v1.0.0:
+          github_org: metal-toolbox
+          repo: vogelkop
+          binary_name: vogelkop
+          filter: linux-amd64
+  - trigger: "vogelkop"
+    if: build.branch == "main" || build.tag =~ /^v[0-9]+\.[0-9]+\.[0-9]+[-staging]*\$/

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -4,7 +4,8 @@ before:
     - go mod download
 
 builds:
-  - id: go
+  - id: vogelkop
+    binary: vogelkop
     env:
       - CGO_ENABLED=0
     goos:
@@ -14,8 +15,8 @@ builds:
       - arm64
       - arm
     goarm:
-      - 6
-      - 7
+      - "6"
+      - "7"
     ldflags:
       - -s -w
       - -X github.com/metal-toolbox/version.appName={{.ProjectName}}
@@ -23,6 +24,11 @@ builds:
       - -X github.com/metal-toolbox/version.commit={{.Commit}}
       - -X github.com/metal-toolbox/version.date={{.Date}}
       - -X github.com/metal-toolbox/version.builtBy=goreleaser
+
+archives:
+  - id: vogelkop
+    format: tar.gz
+    name_template: "{{.ProjectName}}_{{.Version}}_{{.Os}}-{{.Arch}}"
 
 checksum:
   name_template: "checksums.txt"
@@ -37,41 +43,41 @@ changelog:
       - "^docs:"
       - "^test:"
 
-dockers:
-  - use: buildx
-    goos: linux
-    goarch: amd64
-    image_templates:
-      - "ghcr.io/metal-toolbox/{{.ProjectName}}:{{.Tag}}-amd64"
-      - "ghcr.io/metal-toolbox/{{.ProjectName}}:latest-amd64"
-    build_flag_templates:
-      - "--platform=linux/amd64"
-      - "--label=org.opencontainers.image.created={{.Date}}"
-      - "--label=org.opencontainers.image.title={{.ProjectName}}"
-      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
-      - "--label=org.opencontainers.image.version={{.Version}}"
-  - use: buildx
-    goos: linux
-    goarch: arm64
-    image_templates:
-      - "ghcr.io/metal-toolbox/{{.ProjectName}}:{{.Tag}}-arm64"
-      - "ghcr.io/metal-toolbox/{{.ProjectName}}:latest-arm64"
-    build_flag_templates:
-      - "--platform=linux/arm64/v8"
-      - "--label=org.opencontainers.image.created={{.Date}}"
-      - "--label=org.opencontainers.image.title={{.ProjectName}}"
-      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
-      - "--label=org.opencontainers.image.version={{.Version}}"
+# dockers:
+#   - use: buildx
+#     goos: linux
+#     goarch: amd64
+#     image_templates:
+#       - "ghcr.io/metal-toolbox/{{.ProjectName}}:{{.Tag}}-amd64"
+#       - "ghcr.io/metal-toolbox/{{.ProjectName}}:latest-amd64"
+#     build_flag_templates:
+#       - "--platform=linux/amd64"
+#       - "--label=org.opencontainers.image.created={{.Date}}"
+#       - "--label=org.opencontainers.image.title={{.ProjectName}}"
+#       - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+#       - "--label=org.opencontainers.image.version={{.Version}}"
+#   - use: buildx
+#     goos: linux
+#     goarch: arm64
+#     image_templates:
+#       - "ghcr.io/metal-toolbox/{{.ProjectName}}:{{.Tag}}-arm64"
+#       - "ghcr.io/metal-toolbox/{{.ProjectName}}:latest-arm64"
+#     build_flag_templates:
+#       - "--platform=linux/arm64/v8"
+#       - "--label=org.opencontainers.image.created={{.Date}}"
+#       - "--label=org.opencontainers.image.title={{.ProjectName}}"
+#       - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+#       - "--label=org.opencontainers.image.version={{.Version}}"
 
-docker_manifests:
-  - name_template: ghcr.io/metal-toolbox/{{.ProjectName}}:{{.Tag}}
-    image_templates:
-      - ghcr.io/metal-toolbox/{{.ProjectName}}:{{.Tag}}-amd64
-      - ghcr.io/metal-toolbox/{{.ProjectName}}:{{.Tag}}-arm64
-  - name_template: ghcr.io/metal-toolbox/{{.ProjectName}}:latest
-    image_templates:
-      - ghcr.io/metal-toolbox/{{.ProjectName}}:latest-amd64
-      - ghcr.io/metal-toolbox/{{.ProjectName}}:latest-arm64
+# docker_manifests:
+#   - name_template: ghcr.io/metal-toolbox/{{.ProjectName}}:{{.Tag}}
+#     image_templates:
+#       - ghcr.io/metal-toolbox/{{.ProjectName}}:{{.Tag}}-amd64
+#       - ghcr.io/metal-toolbox/{{.ProjectName}}:{{.Tag}}-arm64
+#   - name_template: ghcr.io/metal-toolbox/{{.ProjectName}}:latest
+#     image_templates:
+#       - ghcr.io/metal-toolbox/{{.ProjectName}}:latest-amd64
+#       - ghcr.io/metal-toolbox/{{.ProjectName}}:latest-arm64
 
 signs:
   - cmd: cosign
@@ -86,14 +92,14 @@ signs:
     artifacts: all
     output: true
 
-docker_signs:
-  - cmd: cosign
-    args:
-      - "sign"
-      - "--oidc-issuer=https://token.actions.githubusercontent.com"
-      - "${artifact}"
-    artifacts: all
-    output: true
+# docker_signs:
+#   - cmd: cosign
+#     args:
+#       - "sign"
+#       - "--oidc-issuer=https://token.actions.githubusercontent.com"
+#       - "${artifact}"
+#     artifacts: all
+#     output: true
 
 sboms:
   - artifacts: archive

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
-FROM ghcr.io/equinixmetal/ironlib:v0.2.4
+ARG IRONLIB_IMAGE=ghcr.io/metal-toolbox/ironlib:v0.2.5
+FROM $IRONLIB_IMAGE
 
-COPY vogelkop /vogelkop
+COPY vogelkop /usr/sbin/vogelkop
+RUN chmod 755 /usr/sbin/vogelkop
 
-ENTRYPOINT ["/vogelkop"]
+ENTRYPOINT ["/usr/sbin/vogelkop"]
 CMD ["--help"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
-FROM scratch
+FROM ghcr.io/equinixmetal/ironlib:v0.2.4
+
 COPY vogelkop /vogelkop
+
 ENTRYPOINT ["/vogelkop"]
 CMD ["--help"]


### PR DESCRIPTION
We want to build the resulting vogelkop docker image on top of a private build of the ironlib image.   To facilitate this, this PR updates the Dockerfile and adds a buildkite pipeline.

Additionally we remove the docker image builds from goreleaser's config.