### PR TITLE
Some Dockerfile updates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,7 @@ ARG IRONLIB_REPO=ghcr.io/metal-toolbox
 ARG IRONLIB_TAG=sha256:c06b454b0264a6837cefaf5ba933d0d50c249aa8cbfec6c2ce2e76decb65a02f
 FROM $IRONLIB_REPO/ironlib@$IRONLIB_TAG
 
-COPY vogelkop /usr/sbin/vogelkop
-RUN chmod 755 /usr/sbin/vogelkop
+COPY --chmod=755 vogelkop /usr/sbin/vogelkop
 
 ENTRYPOINT ["/usr/sbin/vogelkop"]
 CMD ["--help"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,11 @@
 ARG IRONLIB_REPO=ghcr.io/metal-toolbox
 ARG IRONLIB_TAG=sha256:c06b454b0264a6837cefaf5ba933d0d50c249aa8cbfec6c2ce2e76decb65a02f
-FROM $IRONLIB_REPO/ironlib@$IRONLIB_TAG
+FROM $IRONLIB_REPO/ironlib@$IRONLIB_TAG as intermediate
 
 COPY --chmod=755 vogelkop /usr/sbin/vogelkop
+
+FROM scratch
+COPY --from=intermediate / /
 
 ENTRYPOINT ["/usr/sbin/vogelkop"]
 CMD ["--help"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 ARG IRONLIB_REPO=ghcr.io/metal-toolbox
-FROM $IRONLIB_REPO/ironlib@sha256:a2237782191cd00fed7e8c2b4e81fe58b52f2a90446621d3459a0f514419aab9
+ARG IRONLIB_TAG=sha256:a2237782191cd00fed7e8c2b4e81fe58b52f2a90446621d3459a0f514419aab9
+FROM $IRONLIB_REPO/ironlib@$IRONLIB_TAG
 
 COPY vogelkop /usr/sbin/vogelkop
 RUN chmod 755 /usr/sbin/vogelkop

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ARG IRONLIB_REPO=ghcr.io/metal-toolbox
-ARG IRONLIB_TAG=sha256:a2237782191cd00fed7e8c2b4e81fe58b52f2a90446621d3459a0f514419aab9
+ARG IRONLIB_TAG=sha256:c06b454b0264a6837cefaf5ba933d0d50c249aa8cbfec6c2ce2e76decb65a02f
 FROM $IRONLIB_REPO/ironlib@$IRONLIB_TAG
 
 COPY vogelkop /usr/sbin/vogelkop


### PR DESCRIPTION
* Separate the ironlib base image tag so we can use one thats available publicly by default.
* Update ironlib base image.
* Added a dependencies empty dir so that docker build would work on a fresh checkout.
* Squashed vogelkop image so its minimal amount of images. Doesn't really do much for this image except for minimize output of docker load, but its nice to have anyway imo. 