### PR TITLE
Rename lint.yaml from goreleaser -> lint

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,4 +1,4 @@
-name: goreleaser
+name: lint
 
 on:
   push:


### PR DESCRIPTION
Probably a copy/paste cleanup that was forgotten.