### PR TITLE
goreleaser: Leave format and name_template to defaults

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -27,8 +27,6 @@ builds:
 
 archives:
   - id: vogelkop
-    format: tar.gz
-    name_template: "{{.ProjectName}}_{{.Version}}_{{.Os}}-{{.Arch}}"
 
 checksum:
   name_template: "checksums.txt"


### PR DESCRIPTION
format was fine, but name_template was broken since it did not take into account goarm version. The default name_template does so we can just use it, might as well leave the format up to default too.