### PR TITLE
Release v0.2.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ARG IRONLIB_REPO=ghcr.io/metal-toolbox
-ARG IRONLIB_TAG=sha-046e1c7
+ARG IRONLIB_TAG=sha256:c06b454b0264a6837cefaf5ba933d0d50c249aa8cbfec6c2ce2e76decb65a02f
 FROM $IRONLIB_REPO/ironlib@$IRONLIB_TAG as intermediate
 
 COPY --chmod=755 vogelkop /usr/sbin/vogelkop

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -2,7 +2,7 @@ package version
 
 var (
 	name    = "vogelkop"
-	version = "0.2.3"
+	version = "0.2.5"
 )
 
 func Name() string {


### PR DESCRIPTION
v0.2.5 adds a working aarch64 docker image, resumes building docker images publicly in github and pins to ironlib v0.2.10.