### PR TITLE
Support deleting raid arrays (virtual disks) by ID

### DIFF
--- a/cmd/raid_delete.go
+++ b/cmd/raid_delete.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"context"
+	"strconv"
 
 	"github.com/spf13/cobra"
 
@@ -30,6 +31,11 @@ func init() {
 func deleteArray(ctx context.Context, raidType, arrayName string) {
 	raidArray := model.RaidArray{
 		Name: arrayName,
+	}
+
+	// If arrayName is actually an integer, populate that as the ControllerVirtualDiskID
+	if id, err := strconv.Atoi(arrayName); err == nil {
+		raidArray.ControllerVirtualDiskID = id
 	}
 
 	if out, err := raidArray.Delete(ctx, raidType); err != nil {

--- a/pkg/model/raid_array.go
+++ b/pkg/model/raid_array.go
@@ -141,7 +141,7 @@ func (a *RaidArray) DeleteHardware(ctx context.Context) error {
 			}
 
 			for _, vd := range vds {
-				if vd.Name == a.Name {
+				if vd.Name == a.Name || vd.ID == strconv.Itoa(a.ControllerVirtualDiskID) {
 					options := &model.DestroyVirtualDiskOptions{
 						VirtualDiskID: a.ControllerVirtualDiskID,
 					}


### PR DESCRIPTION
When calling raid delete --raid-name <string> detect if the <string> is in fact numeric and should be treated as a virtual disk id.  
