### PR TITLE
Handle update to goreleaser v2

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -40,7 +40,7 @@ jobs:
         uses: goreleaser/goreleaser-action@v6.0.0
         with:
           version: latest
-          args: release --rm-dist
+          args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           COSIGN_EXPERIMENTAL: 1

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -39,7 +39,6 @@ jobs:
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6.0.0
         with:
-          version: latest
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,4 +1,5 @@
 project_name: vogelkop
+version: 2
 before:
   hooks:
     - go mod download


### PR DESCRIPTION
We were previously stating `version: latest` in the goreleaser-action step and thus were bumped to v2 of goreleaser itself. v2 dropped `--rm-dist`, now named `--clean`. I opted to handle the update now while its nice and easy instead of later when it would likely be more of a pain.