### PR TITLE
Fix reported version in --version output

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -18,11 +18,7 @@ builds:
       - "7"
     ldflags:
       - -s -w
-      - -X github.com/metal-toolbox/version.appName={{.ProjectName}}
-      - -X github.com/metal-toolbox/version.version={{.Summary}}
-      - -X github.com/metal-toolbox/version.commit={{.Commit}}
-      - -X github.com/metal-toolbox/version.date={{.Date}}
-      - -X github.com/metal-toolbox/version.builtBy=goreleaser
+      - -X github.com/metal-toolbox/vogelkop/internal/version.version={{.Summary}}
 
 dockers:
   - use: buildx

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -19,7 +19,7 @@ builds:
     ldflags:
       - -s -w
       - -X github.com/metal-toolbox/version.appName={{.ProjectName}}
-      - -X github.com/metal-toolbox/version.version={{.Version}}
+      - -X github.com/metal-toolbox/version.version={{.Summary}}
       - -X github.com/metal-toolbox/version.commit={{.Commit}}
       - -X github.com/metal-toolbox/version.date={{.Date}}
       - -X github.com/metal-toolbox/version.builtBy=goreleaser
@@ -36,7 +36,7 @@ dockers:
       - "--label=org.opencontainers.image.created={{.Date}}"
       - "--label=org.opencontainers.image.title={{.ProjectName}}"
       - "--label=org.opencontainers.image.revision={{.FullCommit}}"
-      - "--label=org.opencontainers.image.version={{.Version}}"
+      - "--label=org.opencontainers.image.version={{.Summary}}"
     extra_files:
       - dependencies/.gitignore
   - use: buildx

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -2,7 +2,7 @@ package version
 
 var (
 	name    = "vogelkop"
-	version = "0.2.5"
+	version = "devel"
 )
 
 func Name() string {


### PR DESCRIPTION
We were not using gorleaser correctly before. First it was updating a set of values that do not exist in our dep tree and isn't used. Secondly it wasn't a setting a very useful value `.Version` is only the commit (with `-next` appended if we aren't building off of the tag). `.Summary` gives equivalent output if building off of the tag but additional details if not (example below). Finally, I got rid of the hard coded/outdated version number and replaced with "devel" so that its less misleading/confusing.

Here's an example of how things will look:
```
[13:53:26]-[~/p/g/m/vogelkop]-[manny@c3mv18nix]
git describe --tags 
v0.3.1-3-g8311843
[13:53:32]-[~/p/g/m/vogelkop]-[manny@c3mv18nix]
goreleaser build --snapshot --clean
  • starting build...
  • loading                                          path=.goreleaser.yml
  • skipping validate...
  • loading environment variables
  • getting and validating git state
    • git state                                      commit=8311843274235ab157c22ed21daeca54b83f27fd branch=fix-reported-version current_tag=v0.3.1 previous_tag=v0.3.0 dirty=false
    • pipe skipped                                   reason=disabled during snapshot mode
  • parsing tag
  • setting defaults
  • snapshotting
    • building snapshot...                           version=v0.3.1-next
  • running before hooks
    • running                                        hook=go mod download
  • checking distribution directory
    • cleaning dist
  • setting up metadata
  • storing release metadata
    • writing                                        file=dist/metadata.json
  • loading go mod information
  • build prerequisites
  • writing effective config file
    • writing                                        config=dist/config.yaml
  • building binaries
    • building                                       binary=dist/vogelkop_linux_arm64/vogelkop
    • building                                       binary=dist/vogelkop_linux_amd64_v1/vogelkop
  • storing artifacts metadata
    • writing                                        file=dist/artifacts.json
  • build succeeded after 0s
  • thanks for using goreleaser!
[13:53:34]-[~/p/g/m/vogelkop]-[manny@c3mv18nix]
./dist/vogelkop_linux_amd64_v1/vogelkop --version
vogelkop version v0.3.1-3-g8311843
[13:53:46]-[~/p/g/m/vogelkop]-[manny@c3mv18nix]
git tag -m v0.3.424242 v0.3.424242
[13:53:50]-[~/p/g/m/vogelkop]-[manny@c3mv18nix]
goreleaser build --snapshot --clean
  • starting build...
  • loading                                          path=.goreleaser.yml
  • skipping validate...
  • loading environment variables
  • getting and validating git state
    • git state                                      commit=8311843274235ab157c22ed21daeca54b83f27fd branch=fix-reported-version current_tag=v0.3.424242 previous_tag=v0.3.1 dirty=false
    • pipe skipped                                   reason=disabled during snapshot mode
  • parsing tag
  • setting defaults
  • snapshotting
    • building snapshot...                           version=v0.3.424242-next
  • running before hooks
    • running                                        hook=go mod download
  • checking distribution directory
    • cleaning dist
  • setting up metadata
  • storing release metadata
    • writing                                        file=dist/metadata.json
  • loading go mod information
  • build prerequisites
  • writing effective config file
    • writing                                        config=dist/config.yaml
  • building binaries
    • building                                       binary=dist/vogelkop_linux_arm64/vogelkop
    • building                                       binary=dist/vogelkop_linux_amd64_v1/vogelkop
  • storing artifacts metadata
    • writing                                        file=dist/artifacts.json
  • build succeeded after 0s
  • thanks for using goreleaser!
[13:53:52]-[~/p/g/m/vogelkop]-[manny@c3mv18nix]
./dist/vogelkop_linux_amd64_v1/vogelkop --version
vogelkop version v0.3.424242
```