### PR TITLE
Fix both disk wipe and deprecated command invocations

### DIFF
--- a/cmd/disk_partition.go
+++ b/cmd/disk_partition.go
@@ -43,9 +43,8 @@ func init() {
 
 	diskCommand.AddCommand(diskPartitionCommand)
 
-	rootCmd.AddCommand(&cobra.Command{
-		Use:        "partition-disk",
-		Deprecated: "use \"disk partition\"",
-		Run:        diskPartitionCommand.Run,
-	})
+	deprecated := *diskPartitionCommand
+	deprecated.Use = "partition-disk"
+	deprecated.Deprecated = "use \"disk partition\""
+	rootCmd.AddCommand(&deprecated)
 }

--- a/cmd/disk_wipe.go
+++ b/cmd/disk_wipe.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"os"
+	"time"
 
 	"github.com/bmc-toolbox/common"
 	"github.com/metal-toolbox/ironlib"
@@ -32,9 +33,9 @@ func init() {
 				logger.With("error", err).Fatal("--timeout argument is invalid")
 			}
 
-			verbose, err := cmd.Flags().GetBool("verbose")
+			verbose, err := cmd.Flags().GetBool("debug")
 			if err != nil {
-				logger.With("error", err).Fatal("--verbose argument is invalid")
+				logger.With("error", err).Fatal("--debug argument is invalid")
 			}
 
 			driveName := args[0]
@@ -90,5 +91,6 @@ func init() {
 		},
 	}
 
+	diskCommand.PersistentFlags().Duration("timeout", 1*time.Minute, "Time to wait for wipe to complete")
 	diskCommand.AddCommand(cmd)
 }

--- a/cmd/partition_format.go
+++ b/cmd/partition_format.go
@@ -7,7 +7,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var partitionFormatPartitionCommand = &cobra.Command{
+var partitionFormatCommand = &cobra.Command{
 	Use:   "format",
 	Short: "Formats a partition",
 	Long:  "Formats a partition with your choice of filesystem",
@@ -49,21 +49,21 @@ var partitionFormatPartitionCommand = &cobra.Command{
 }
 
 func init() {
-	partitionFormatPartitionCommand.PersistentFlags().String("device", "", "Block device")
-	partitionFormatPartitionCommand.PersistentFlags().String("filesystem-device", "", "Filesystem Block device")
+	partitionFormatCommand.PersistentFlags().String("device", "", "Block device")
+	partitionFormatCommand.PersistentFlags().String("filesystem-device", "", "Filesystem Block device")
 
-	partitionFormatPartitionCommand.PersistentFlags().Uint("partition", 0, "Partition number")
+	partitionFormatCommand.PersistentFlags().Uint("partition", 0, "Partition number")
 
-	partitionFormatPartitionCommand.PersistentFlags().String("format", "ext4", "Filesystem to be applied to the partition")
-	markFlagAsRequired(partitionFormatPartitionCommand, "format")
+	partitionFormatCommand.PersistentFlags().String("format", "ext4", "Filesystem to be applied to the partition")
+	markFlagAsRequired(partitionFormatCommand, "format")
 
-	partitionFormatPartitionCommand.PersistentFlags().String("mount-point", "/", "Filesystem mount point")
-	partitionFormatPartitionCommand.PersistentFlags().StringSlice("options", []string{}, "Filesystem creation options")
-	partitionCommand.AddCommand(partitionFormatPartitionCommand)
+	partitionFormatCommand.PersistentFlags().String("mount-point", "/", "Filesystem mount point")
+	partitionFormatCommand.PersistentFlags().StringSlice("options", []string{}, "Filesystem creation options")
+	partitionCommand.AddCommand(partitionFormatCommand)
 
 	rootCmd.AddCommand(&cobra.Command{
 		Use:        "format-partition",
 		Deprecated: "use \"partition format\"",
-		Run:        partitionFormatPartitionCommand.Run,
+		Run:        partitionFormatCommand.Run,
 	})
 }

--- a/cmd/partition_format.go
+++ b/cmd/partition_format.go
@@ -61,9 +61,8 @@ func init() {
 	partitionFormatCommand.PersistentFlags().StringSlice("options", []string{}, "Filesystem creation options")
 	partitionCommand.AddCommand(partitionFormatCommand)
 
-	rootCmd.AddCommand(&cobra.Command{
-		Use:        "format-partition",
-		Deprecated: "use \"partition format\"",
-		Run:        partitionFormatCommand.Run,
-	})
+	deprecated := *partitionFormatCommand
+	deprecated.Use = "format-partition"
+	deprecated.Deprecated = "use \"partition format\""
+	rootCmd.AddCommand(&deprecated)
 }


### PR DESCRIPTION
I did not notice that the deprecated commands I setup were missing the flags and would fail to run. My initial attempt to deprecate the old names did nothing until I set the `Run` attribute but then I failed to notice that the args were missing and the `Run` would fail. I have checked that both old and new funcs actually run this time though.

Also ran into cli flags for disk wipe. I had the missing flags at one point while testing stuff out but then just totally forgot to re-run/test when I replaced `verbose` with pre-existing `debug`. I ran a wipe with/without timeout,debug to make sure it works as expected, including a tiny timeout that causes the command to abort/error out.