### PR TITLE
Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @joelrebel @mmlb @splaspood @DoctorVin
+* @metal-toolbox/provisioning-core


### PR DESCRIPTION
### What does this PR do
Remove users who no longer are part of the project, and add the provisioning-core group.
