### PR TITLE
Log the summary of the wipe result

### DIFF
--- a/cmd/disk_wipe.go
+++ b/cmd/disk_wipe.go
@@ -24,66 +24,77 @@ var (
 	ErrDriveWiperNotFound = errors.New("failed to find appropriate drive wiper")
 )
 
-type diskWipeResult struct {
-	DriveName string `json:"drive_name"`
-	Fail      bool   `json:"success"`
-	Err       string `json:"error,omitempty"`
+type wiperInfo struct {
+	Disk        string `json:"disk"`
+	Action      string `json:"action"`
+	Method      string `json:"method"`
+	ElapsedTime int    `json:"elapsed_time"`
+	Result      string `json:"result"`
 }
 
-func wipeDisks(ctx context.Context, drivesName []string, collector actions.DeviceManager, logger *logrus.Logger, verbose bool) {
+func wipeDisks(ctx context.Context, drivesName []string, collector actions.DeviceManager, wipeResults []*wiperInfo, logger *logrus.Logger, logResultFilename string, verbose bool) {
 	inventory, err := collector.GetInventory(ctx, actions.WithDynamicCollection())
 	if err != nil {
 		logger.WithError(err).Fatal("exiting")
 	}
 
-	wipeResultsCh := make(chan *diskWipeResult, 1)
-	go func() {
-		var failureResults []*diskWipeResult
-		for result := range wipeResultsCh {
-			if result.Fail {
-				failureResults = append(failureResults, result)
-			}
-		}
-		if len(failureResults) > 0 {
-			jsonData, marshalErr := json.Marshal(failureResults)
-			if marshalErr != nil {
-				logger.Fatalf("Error marshaling %v to JSON: %v", failureResults, marshalErr)
-				return
-			}
-			logger.Fatal(string(jsonData))
-		}
-	}()
-
+	var hasFailure bool
 	var wg sync.WaitGroup
 	wg.Add(len(drivesName))
 	for _, driveName := range drivesName {
 		go func() {
+			defer wg.Done()
 			l := logger.WithField("drive", driveName)
-			err = wipeOneDisk(ctx, inventory, driveName, &wg, verbose)
-			wipeResultsCh <- &diskWipeResult{driveName, true, err.Error()}
-			if err != nil {
-				// we may want to see error message as soon as possible
-				l.Errorf("failed to wipe disk %v: error %v", driveName, err)
-				return
+			wi := &wiperInfo{
+				Disk:   driveName,
+				Result: "success",
 			}
-			l.Infof("wipe drive %v done", driveName)
+			startTime := time.Now()
+			if err = wipeOneDisk(ctx, inventory, wi, verbose); err != nil {
+				hasFailure = true
+				wi.Result = "failure"
+				l.Errorf("failed to wipe disk %v: error %v", driveName, err)
+			} else {
+				l.Infof("wipe drive %v done", driveName)
+			}
+			wi.ElapsedTime = int(time.Since(startTime).Round(time.Second).Seconds())
+			wipeResults = append(wipeResults, wi)
 		}()
 	}
 	wg.Wait()
-	close(wipeResultsCh)
+	wipeResultsJSON, marshalErr := json.MarshalIndent(wipeResults, "", "  ") // pretty printing
+	if marshalErr != nil {
+		logger.Fatalf("Error marshaling %v to JSON: %v", wipeResults, marshalErr)
+	}
+
+	if logResultFilename != "" {
+		file, err := os.Create(logResultFilename)
+		if err != nil {
+			logger.Fatalf("failed to create %v: %v", logResultFilename, err)
+		}
+		defer file.Close()
+
+		if _, err := file.Write(wipeResultsJSON); err != nil {
+			logger.Fatalf("failed to write result to %v: %v", logResultFilename, err)
+		}
+
+		if hasFailure {
+			logger.Fatal(string(wipeResultsJSON))
+		}
+	}
+	logger.Info(string(wipeResultsJSON))
 }
 
 // nolint:gocyclo // easier to read in one big function I think
-func wipeOneDisk(ctx context.Context, inventory *common.Device, driveName string, wg *sync.WaitGroup, verbose bool) error {
-	defer wg.Done()
-
+func wipeOneDisk(ctx context.Context, inventory *common.Device, wi *wiperInfo, verbose bool) error {
 	var drive *common.Drive
 	for _, d := range inventory.Drives {
-		if d.LogicalName == driveName {
+		if d.LogicalName == wi.Disk {
 			drive = d
 			break
 		}
 	}
+
 	if drive == nil {
 		return ErrDriveNotExist
 	}
@@ -92,12 +103,42 @@ func wipeOneDisk(ctx context.Context, inventory *common.Device, driveName string
 	var wiper actions.DriveWiper
 	switch drive.Protocol {
 	case "nvme":
+		var ber bool
+		var cer bool
+		var cese bool
+		for _, cap := range drive.Capabilities {
+			switch cap.Name {
+			case "ber":
+				ber = cap.Enabled
+			case "cer":
+				cer = cap.Enabled
+			case "cese":
+				cese = cap.Enabled
+			}
+		}
+		switch {
+		case cer:
+			wi.Method = "sanitize"
+			wi.Action = "CryptoErase"
+		case ber:
+			wi.Method = "sanitize"
+			wi.Action = "BlockErase"
+		case cese:
+			wi.Method = "format"
+			wi.Action = "CryptographicErase"
+		default:
+			wi.Method = "format"
+			wi.Action = "UserDataErase"
+		}
 		wiper = utils.NewNvmeCmd(verbose)
 	case "sata", "sas":
 		// Lets figure out the drive capabilities in an easier format
 		var sanitize bool
 		var esee bool
 		var trim bool
+		var eseu bool
+		var bee bool
+		var cse bool
 		for _, cap := range drive.Capabilities {
 			switch {
 			case cap.Description == "encryption supports enhanced erase":
@@ -106,18 +147,39 @@ func wipeOneDisk(ctx context.Context, inventory *common.Device, driveName string
 				sanitize = cap.Enabled
 			case strings.HasPrefix(cap.Description, "Data Set Management TRIM supported"):
 				trim = cap.Enabled
+			case cap.Description == "BLOCK ERASE EXT":
+				bee = cap.Enabled
+			case cap.Description == "CRYPTO SCRAMBLE EXT":
+				cse = cap.Enabled
+			case strings.HasPrefix(cap.Description, "erase time:"):
+				eseu = strings.Contains(cap.Description, "enhanced")
 			}
 		}
 
 		switch {
 		case sanitize || esee:
+			// It is better if ironlib util can export an API to provide cap info, or
+			// WipeDrive can return methods/actions it uses:
+			// https://github.com/metal-toolbox/ironlib/blob/main/utils/hdparm.go#L217-L237
+			switch {
+			case sanitize && cse:
+				wi.Method = "sanitize"
+				wi.Action = "sanitize-crypto-scramble"
+			case sanitize && bee:
+				wi.Method = "sanitize"
+				wi.Action = "sanitize-block-erase"
+			case esee && eseu:
+				wi.Method = "security-erase-enhanced"
+			}
 			// Drive supports Sanitize or Enhanced Erase, so we use hdparm
 			wiper = utils.NewHdparmCmd(verbose)
 		case trim:
 			// Drive supports TRIM, so we use blkdiscard
+			wi.Method = "blkdiscard"
 			wiper = utils.NewBlkdiscardCmd(verbose)
 		default:
 			// Drive does not support any preferred wipe method so we fall back to filling it up with zeros
+			wi.Method = "fillzero"
 			wiper = utils.NewFillZeroCmd(verbose)
 		}
 	}
@@ -161,6 +223,11 @@ func init() {
 				logger.With("error", err).Fatal("--debug argument is invalid")
 			}
 
+			logResultFilename, err := cmd.Flags().GetString("output")
+			if err != nil {
+				logger.With("error", err).Fatal("--output argument is invalid")
+			}
+
 			logger := logrus.New()
 			logger.Formatter = new(logrus.TextFormatter)
 			if verbose {
@@ -171,19 +238,28 @@ func init() {
 			ctx, cancel := context.WithTimeout(ctx, timeout)
 			defer cancel()
 
+			var wipeResults []*wiperInfo
 			var drivesName []string
 			drivesNameMap := make(map[string]struct{})
 			// is regex better?
-			for _, driveName := range strings.Split(args[0], ",") {
+			for _, driveName := range args {
 				_, err = os.Stat(driveName)
 				if err != nil {
 					// should we ignore errors and let inventory collector to handle errors like permission, I/O, os errors
 					// or handle file not exist error here is good enough?
 					logger.Warnf("invalid drive %v: %v", driveName, err)
+					wipeResults = append(wipeResults, &wiperInfo{
+						Disk:   driveName,
+						Result: "failure",
+					})
 					continue
 				}
 				if _, exists := drivesNameMap[driveName]; exists {
 					logger.Warnf("duplicate drive input %v", driveName)
+					wipeResults = append(wipeResults, &wiperInfo{
+						Disk:   driveName,
+						Result: "failure",
+					})
 					continue
 				}
 				drivesNameMap[driveName] = struct{}{}
@@ -195,10 +271,11 @@ func init() {
 				logger.WithError(err).Fatal("exiting")
 			}
 
-			wipeDisks(ctx, drivesName, collector, logger, verbose)
+			wipeDisks(ctx, drivesName, collector, wipeResults, logger, logResultFilename, verbose)
 		},
 	}
 
+	diskCommand.PersistentFlags().String("output", "", "log wiping results to the file with json format")
 	diskCommand.PersistentFlags().Duration("timeout", 1*time.Minute, "Time to wait for wipe to complete")
 	diskCommand.AddCommand(cmd)
 }

--- a/cmd/disk_wipe_test.go
+++ b/cmd/disk_wipe_test.go
@@ -285,7 +285,8 @@ func TestWiping(t *testing.T) {
 			}
 
 			logger := logrus.New()
-			wipeDisks(ctx, wipeDrives, collector, logger, true)
+			var wipeResults []*wiperInfo
+			wipeDisks(ctx, wipeDrives, collector, wipeResults, logger, "", true)
 			if err := verifyWipeSuccess(wipedDrives, unWipedDrives, fileContent); err != nil {
 				t.Errorf("failed to wipe drives: %v", err)
 			}


### PR DESCRIPTION
Introduced an extra struct to make the summary log prettier.

Only show `wipe_error` when there are errors.
Only show `capabilities` when verbose is enabled.

Example of the happy log `INFO`:
```
INFO[0006] [
  {
    "drive_name": {
      "drive_name": "/dev/nvme2n1",
      "protocol": "nvme",
      "capabilities": null,
      "wiper": "nvme",
      "elapsed_time": "1.14s"
    }
  },
  {
    "drive_name": {
      "drive_name": "/dev/nvme3n1",
      "protocol": "nvme",
      "capabilities": null,
      "wiper": "nvme",
      "elapsed_time": "1.17s"
    }
  },
  {
    "drive_name": {
      "drive_name": "/dev/nvme1n1",
      "protocol": "nvme",
      "capabilities": null,
      "wiper": "nvme",
      "elapsed_time": "4.68s"
    }
  }
] 
```

Example of the failure log `FATAL`:
```
FATA[0006] [
  {
    "drive_name": {
      "drive_name": "/dev/nvme2n1",
      "protocol": "nvme",
      "capabilities": null,
      "wiper": "nvme",
      "elapsed_time": "1.17s"
    }
  },
  {
    "drive_name": {
      "drive_name": "/dev/nvme3n1",
      "protocol": "nvme",
      "capabilities": null,
      "wiper": "nvme",
      "elapsed_time": "1.17s"
    }
  },
  {
    "drive_name": {
      "drive_name": "/dev/nvme1n1",
      "protocol": "nvme",
      "capabilities": null,
      "wiper": "nvme",
      "elapsed_time": "4.67s"
    },
    "wipe_error": "wiper.WipeDrive() failed to wipe drive: found left over data after wiping disk"
  }
]
```